### PR TITLE
タスク管理機能　管理実装　ビューは未だ

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,3 +63,4 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'haml-rails'
 gem 'devise'
+gem 'enum_help'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.9.0)
     erubis (2.7.0)
     execjs (2.7.0)
@@ -234,6 +236,7 @@ DEPENDENCIES
   chromedriver-helper
   coffee-rails (~> 4.2)
   devise
+  enum_help
   haml-rails
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,7 +17,9 @@
 //  @import "./reset";
  @import "shared/header";
  @import "shared/sidebar";
-
+//  @import "bootstrap";
+ @import "task/index.scss";
+ 
  body {
   background-color: white;
 }

--- a/app/assets/stylesheets/task/index.scss
+++ b/app/assets/stylesheets/task/index.scss
@@ -1,0 +1,3 @@
+.form-wrapper {
+  padding: 20px;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
 # 今後実装するもの　current_memberメソッドでsession_id取得する
 # before_action :authenticate_member!
 before_action :configure_permitted_parameters, if: :devise_controller?
+protect_from_forgery with: :exception
 
 private
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,0 +1,25 @@
+class TasksController < ApplicationController
+
+  def index
+    @task = Task.new
+    @tasks = Task.incoming.order(start_at: :asc)
+  end
+
+  def create
+    @task = Task.new(task_params)
+    @task.save
+    redirect_to tasks_path
+  end
+
+  def update
+    @task = Task.find(params[:id])
+    @task.update_finished_true
+    redirect_to tasks_path
+  end
+
+  private
+
+  def task_params
+    params.require(:task).permit(:title, :content, :start_at, :finish_at, :kind, :finished)
+  end
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,4 +2,13 @@ class Task < ApplicationRecord
   belongs_to :member
   belongs_to :room,dependent: :destroy
   has_many :comments,dependent: :destroy
+
+  enum kind: {individual: 0, work: 1, others: 2}
+
+  scope :incoming, -> { where('start_at > ?', Time.zone.now) }
+
+  def update_finished_true
+    self.finished = true if self.finished == false
+    self.save
+  end
 end

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -6,7 +6,7 @@
   %ul
     = link_to "TOP", :root
     = link_to "ニュース", "#"
-    = link_to "業務登録", "#"
+    = link_to "業務登録", :tasks
     = link_to "会員管理", :members
 -#  チーム一覧おリンクトゥにはクラスなどをつけてjavascuriptにてリンク一覧表示
 

--- a/app/views/tasks/_task_html.haml
+++ b/app/views/tasks/_task_html.haml
@@ -1,0 +1,18 @@
+%tr
+  %td
+    = task.kind_i18n
+  %td
+    = task.title
+  %td
+    = task.content
+  %td
+    = task.start_at
+  %td
+    = task.finish_at
+  %td
+    - if task.finished?
+      完了済
+    - else
+      未完了
+      %br
+      = link_to "完了にする", task_path(task), method: :patch, class: "btn btn-primary "

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -1,0 +1,36 @@
+%nav.navbar.navbar-light{style: :"background-color: #e3f2fd;" }
+  %a.navbar-brand 登録済みタスク一覧
+
+.form-wrapper
+  = form_for @task, html: {class: 'form-group'} do |f|
+
+    = f.label :kind
+    = f.select :kind, Task.kinds_i18n.invert, {}, class: 'form-control', placeholder: 0
+
+    = f.label :title
+    = f.text_field :title, class: 'form-control', placeholder: "ここにタスク名を入力してください"
+
+    = f.label :content
+    = f.text_area :content, class: 'form-control', placeholder: "ここにタスクの詳細を入力してください"
+
+    = f.label :start_at
+    = f.datetime_select :start_at, ampm: :true, minute_step: 15, default: (Time.zone.now + 1.days), class: 'form-control'
+
+    = f.label :finish_at
+    = f.datetime_select :finish_at, ampm: :true, minute_step: 15, default: (Time.zone.now + 2.days), class: 'form-control'
+
+    = f.submit '作成する', class: "btn btn-primary"
+
+.table-responsive
+  %h4.r-title-label{style: 'display: inline-block; margin-right: 20px; '}
+  %table.table.table-striped.b-t.b-light
+    %thead
+      %tr
+        %th 種類
+        %th タスクの名前
+        %th タスクの内容
+        %th 開始時間
+        %th 終了時間
+        %th 状態
+    %tbody
+      = render @tasks

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,4 +17,6 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :tasks
+
 end


### PR DESCRIPTION
＃WHAT
・タスクの登録画面の実装　タスク登録機能の実装

＃WHY
・お互いの業務を管理してフォローし合う為
・セラピスト本人が1日の業務を把握し、タイムスケジュールを取りやすくする為
・管理者が業務の割り振りを簡便に行う為