### PR TITLE
コメント欄の枠をカラーリング　時間などもついでに表記できるように

### DIFF
--- a/app/assets/stylesheets/message/index.scss
+++ b/app/assets/stylesheets/message/index.scss
@@ -2,6 +2,43 @@
   .chat_message_index_list{
     height: calc(100vh - 420px);
     overflow: scroll;
+    .chat_message_index_list_index{
+      .chat_message_index_list_value{
+        padding: 10px 0px 10px 10px;
+        margin-bottom: 10px;
+        display: flex;
+        .chat_message_index_list_index_name{
+          font-size: 25px;
+        }
+        .chat_message_index_list_index_time{
+          font-size: 16px;
+          padding: 10px;
+        }
+      }
+      .chat_message_index_list_index_content{
+        padding: 10px 0px 10px 10px;
+        font-size: 20px;
+      }
+    }
+    .chat_message_index_list_index:nth-child(odd){
+      background-color: rgba(0, 0, 0, 0.05);
+      .chat_message_index_list_value{
+        padding: 10px 0px 10px 10px;
+        margin-bottom: 10px;
+        display: flex;
+        .chat_message_index_list_index_name{
+          font-size: 25px;
+        }
+        .chat_message_index_list_index_time{
+          font-size: 16px;
+          padding: 10px;
+        }
+      }
+      .chat_message_index_list_index_content{
+        padding: 10px 0px 10px 10px;
+        font-size: 20px;
+      }
+    }
   }
   .chat_message_input{
     .chat_message_input_form{

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -7,7 +7,13 @@
     .chat_message_index_list
       - @room.messages.each do |message|
         .chat_message_index_list_index
-          = message.content
+          .chat_message_index_list_value
+            .chat_message_index_list_index_name
+              = message.member.user_name
+            .chat_message_index_list_index_time
+              = message.created_at.strftime("%Y/%m/%d %H:%M")
+          .chat_message_index_list_index_content
+            = message.content
     .chat_message_input
       .chat_message_input_form
         = form_with model: [@room,@message], url: room_message_make_message_path(current_member.id), method: :post, local: true do |f|


### PR DESCRIPTION
＃WHAT
①.chat_message_index_list_indexの奇数を灰色にカラーリングできるように変更した
②メッセージ内容に時間、名前を表示できるようにした

＃WHY
①コメント欄の区切りがパット見てわかるように
②誰が、いつコメントを書いたのかをわかるようにするため（時間帯がわからないと仕事の引き継ぎもできないから）